### PR TITLE
Add functionality to delete favorite endpoint

### DIFF
--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,5 +1,7 @@
 class Api::V1::FavoritesController < ApplicationController
-  before_action :verify_user
+  before_action :verify_user, except: %i[destroy]
+  before_action :find_favorite, only: %i[destroy]
+
   def index
     favorites = Favorite.find_my_favorites(params[:api_key])
     render json: FavoriteSerializer.new(favorites)
@@ -10,7 +12,17 @@ class Api::V1::FavoritesController < ApplicationController
     render json: { 'success': 'Favorite added successfully' }, status: :created
   end
 
+  def destroy
+    Favorite.destroy(@favorite.id)
+    head :no_content, status: 204
+  end
+
   private
+
+  def find_favorite
+    @favorite = Favorite.find_by(api_key: params[:api_key], recipe_link: params[:recipe_link])
+    return render json: ErrorSerializer.favorite_not_found, status: 400 if @favorite.nil?
+  end
 
   def verify_user
     @user = User.find_by(api_key: params[:api_key])

--- a/app/controllers/api/v1/favorites_controller.rb
+++ b/app/controllers/api/v1/favorites_controller.rb
@@ -1,4 +1,5 @@
 class Api::V1::FavoritesController < ApplicationController
+  before_action :verify_params, only: %i[destroy index]
   before_action :verify_user, except: %i[destroy]
   before_action :find_favorite, only: %i[destroy]
 
@@ -8,8 +9,12 @@ class Api::V1::FavoritesController < ApplicationController
   end
   
   def create 
-    @user.favorites.create(favorite_params)
-    render json: { 'success': 'Favorite added successfully' }, status: :created
+    new_favorite = @user.favorites.new(favorite_params)
+    if new_favorite.save 
+      render json: { 'success': 'Favorite added successfully' }, status: :created
+    else
+      render json: ErrorSerializer.missing_params, status: 400
+    end
   end
 
   def destroy
@@ -18,6 +23,26 @@ class Api::V1::FavoritesController < ApplicationController
   end
 
   private
+
+  def verify_params
+    if params[:action] == 'destroy'
+      verify_destroy_params
+    elsif params[:action] == 'index'
+      verify_index_params
+    end
+  end
+
+  def verify_index_params
+    if params[:api_key].nil?
+      return render json: ErrorSerializer.missing_params, status: 400
+    end
+  end
+
+  def verify_destroy_params
+    if params[:api_key].nil? || params[:recipe_link].nil?
+      return render json: ErrorSerializer.missing_params, status: 400
+    end
+  end
 
   def find_favorite
     @favorite = Favorite.find_by(api_key: params[:api_key], recipe_link: params[:recipe_link])

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::UsersController < ApplicationController
     if new_user.save
       render json: UserSerializer.new(new_user), status: :created
     else
-      render json: ErrorSerializer.user_error(new_user.errors), status: 400
+      render json: ErrorSerializer.user_creation_error(new_user.errors), status: 400
     end
   end
 

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -11,7 +11,7 @@ class ErrorSerializer
     }
   end
 
-  def self.user_error(errors)
+  def self.user_creation_error(errors)
     {
       'errors': [
         {
@@ -41,6 +41,18 @@ class ErrorSerializer
         {
           "status": 'PLEASE TRY AGAIN',
           "message": "Favorite does not exist",
+          "code": 400
+        }
+      ]
+    }
+  end
+
+  def self.missing_params
+    {
+      'errors': [
+        {
+          "status": 'PLEASE TRY AGAIN',
+          "message": "Make sure to include all necessary params",
           "code": 400
         }
       ]

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -34,4 +34,16 @@ class ErrorSerializer
       ]
     }
   end
+
+  def self.favorite_not_found
+    {
+      'errors': [
+        {
+          "status": 'PLEASE TRY AGAIN',
+          "message": "Favorite does not exist",
+          "code": 400
+        }
+      ]
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       resources :recipes, only: %i[index]
       resources :users, only: %i[create]
       resources :favorites, only: %i[create index]
+      delete '/favorites', to: 'favorites#destroy'
     end
   end
 end

--- a/spec/requests/delete_favorite_spec.rb
+++ b/spec/requests/delete_favorite_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Delete a Favorite' do
     expect(Favorite.count).to eq(1)
   end
 
-  it 'returns an error message if no favorite is found' do
+  it 'returns an appropriate error message if no favorite is found' do
     params = { 'api_key': "igotthekeys", 'recipe_link': 'https://www.justonecookbook.com/okinawa-soba/'}
     delete '/api/v1/favorites', headers: @headers, params: params, as: :json
 
@@ -32,5 +32,16 @@ RSpec.describe 'Delete a Favorite' do
     expect(parsed_response).to have_key :errors
     expect(parsed_response[:errors][0][:status]).to eq('PLEASE TRY AGAIN')
     expect(parsed_response[:errors][0][:message]).to eq('Favorite does not exist')
+  end
+
+  it 'returns an appropriate error message if params are missing' do
+    params = { 'api_key': "igotthekeys"}
+    delete '/api/v1/favorites', headers: @headers, params: params, as: :json
+
+    expect(response.status).to eq(400)
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+    expect(parsed_response).to have_key :errors
+    expect(parsed_response[:errors][0][:status]).to eq('PLEASE TRY AGAIN')
+    expect(parsed_response[:errors][0][:message]).to eq('Make sure to include all necessary params')
   end
 end

--- a/spec/requests/delete_favorite_spec.rb
+++ b/spec/requests/delete_favorite_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'Delete a Favorite' do
+  before do
+    @headers = { 'CONTENT_TYPE' => 'application/json', 'Accept' => 'application/json'}
+    body = { 'name': 'Monkey Luffy', 'email': 'pirateking@onepiece.jp' }
+    post '/api/v1/users', headers: headers, params: body, as: :json
+    @user = User.last
+
+    body_2 = { 'api_key': "#{@user.api_key}", 'country': 'Japan', 'recipe_link': 'https://www.justonecookbook.com/okinawa-soba/', 'recipe_title': 'Okinawa Soba 沖縄そば'}
+    body_3 = { 'api_key': "#{@user.api_key}", 'country': 'Japan', 'recipe_link': 'https://www.justonecookbook.com/homemade-miso-soup/', 'recipe_title': 'Miso Soup'}
+    post '/api/v1/favorites', headers: @headers, params: body_2, as: :json
+    post '/api/v1/favorites', headers: @headers, params: body_3, as: :json
+  end
+
+  it 'deletes a favorite from the database' do
+    expect(Favorite.count).to eq(2)
+    params = { 'api_key': "#{@user.api_key}", 'recipe_link': 'https://www.justonecookbook.com/okinawa-soba/'}
+    delete '/api/v1/favorites', headers: @headers, params: params, as: :json
+    
+    expect(response).to be_successful
+    expect(response.status).to eq(204)
+    expect(Favorite.count).to eq(1)
+  end
+
+  it 'returns an error message if no favorite is found' do
+    params = { 'api_key': "igotthekeys", 'recipe_link': 'https://www.justonecookbook.com/okinawa-soba/'}
+    delete '/api/v1/favorites', headers: @headers, params: params, as: :json
+
+    expect(response.status).to eq(400)
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+    expect(parsed_response).to have_key :errors
+    expect(parsed_response[:errors][0][:status]).to eq('PLEASE TRY AGAIN')
+    expect(parsed_response[:errors][0][:message]).to eq('Favorite does not exist')
+  end
+end

--- a/spec/requests/get_a_users_favorites_spec.rb
+++ b/spec/requests/get_a_users_favorites_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Get A User\'s Favorites' do
     expect(parsed_response[:data]).to eq([])
   end
 
-  it 'sends an error message with appropriate response if the api_key is invalid' do
+  it 'sends an appropriate error message with appropriate response if the api_key is invalid' do
     params = { 'api_key': "keyskeyskeys" }
     get "/api/v1/favorites", headers: @headers, params: params
 
@@ -60,5 +60,15 @@ RSpec.describe 'Get A User\'s Favorites' do
     expect(parsed_response).to have_key :errors
     expect(parsed_response[:errors][0][:status]).to eq('PLEASE TRY AGAIN')
     expect(parsed_response[:errors][0][:message]).to eq('User does not exist')
+  end
+
+   it 'returns an appropriate error message if params are missing' do
+    get "/api/v1/favorites", headers: @headers
+
+    expect(response.status).to eq(400)
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+    expect(parsed_response).to have_key :errors
+    expect(parsed_response[:errors][0][:status]).to eq('PLEASE TRY AGAIN')
+    expect(parsed_response[:errors][0][:message]).to eq('Make sure to include all necessary params')
   end
 end

--- a/spec/requests/post_favorites_spec.rb
+++ b/spec/requests/post_favorites_spec.rb
@@ -31,4 +31,15 @@ RSpec.describe 'Post Favorites' do
     expect(parsed_response[:errors][0][:status]).to eq('PLEASE TRY AGAIN')
     expect(parsed_response[:errors][0][:message]).to eq('User does not exist')
   end
+
+  it 'sends an appropriate error message if the body is missing some params' do
+    body = { 'api_key': "#{@user.api_key}", 'recipe_link': 'https://www.justonecookbook.com/okinawa-soba/', 'recipe_title': 'Okinawa Soba 沖縄そば'}
+    post '/api/v1/favorites', headers: @headers, params: body, as: :json
+
+    expect(response.status).to eq(400)
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+    expect(parsed_response).to have_key :errors
+    expect(parsed_response[:errors][0][:status]).to eq('PLEASE TRY AGAIN')
+    expect(parsed_response[:errors][0][:message]).to eq('Make sure to include all necessary params')
+  end
 end


### PR DESCRIPTION
Neccesary checkmarks:

    [x] All Tests are Passing
    [x] The code will run locally

Type of change

    [x] New feature
    [] Bug Fix

Implements/Fixes:

    - Add DELETE `/api/v1/favorites` endpoint - used api_key and recipe_link as params
    - Add happy path and sad path testing (also added sad path testing for getting a users favorites and posting a favorite specific to if params are missing)

Check the correct boxes

    [x] This broke nothing
    [] This broke some stuff
    [] This broke everything

Testing Changes

    [] No Tests have been changed
    [x] Some Tests have been changed
    [] All of the Tests have been changed(Please describe what in the world happened)

Checklist:

    [x] My code has no unused/commented out code
    [x] I have reviewed my code
    [] I have commented my code, particularly in hard-to-understand areas
    [x] I have fully tested my code

GIF ME
<img src="https://media3.giphy.com/media/4OV1bLOIWwIXRxpXlN/giphy.gif"/>